### PR TITLE
Publish Governance

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,18 @@
+name: Deploy docs
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: SciCatProject/docs-template/.github/actions/mkdocs-pages@main
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          push: true
+          docs_folder: ''


### PR DESCRIPTION
# What does this MR do
This MR adds the necessary files from the `docs-template` repository so that the governance will be published via Github-Pages.

This will allow anyone interested in the project to easily view the governance for the project.

# Notes
Currently the publication is set to run on the `main` branch. We may want to consider to update this to a release branch in future. 
