### PR TITLE
Added Max IV steering committee member

### DIFF
--- a/roles/STEERING-COMMITTEE.md
+++ b/roles/STEERING-COMMITTEE.md
@@ -23,6 +23,7 @@ __IMPORTANT__:
 | Bridget Murphy | --- | DAPHNE | Preliminary |
 | Philipp Neumann | --- | DESY | Preliminary |
 | Daphne van Dijken | --- | Dectris | Preliminary |
+| Marjam Lindberg | --- | MaxIV | Preliminary |
 | --- | --- | --- | --- |
   
 


### PR DESCRIPTION
This PR adds MaxIV steering committee member.

### AI Contributions

PRs are the responsibility of the human submitter, as described in the [contributing guidelines](https://www.scicatproject.org/governance/main/procedures/CONTRIBUTING/#ai-contributions). Check one:
- [ ] Fully human coded
- [x] Assisted-by: Mistral.ai:mistral-medium-3.5 [VSCode Mistral.ai vibe code ] 