### PR TITLE
Allow conceptual review for large-impact PRs

### DIFF
--- a/procedures/CONTRIBUTING.md
+++ b/procedures/CONTRIBUTING.md
@@ -73,6 +73,7 @@ The following rules must be followed if AI is used in any PR contributed to the 
 
 - Must be reviewed by **at least two maintainers**.
 - At least **one reviewer must be from a different institution or group**.
+- At least one review should be a **technical review** giving detailed feedback about code changes. The second review may be a **conceptual review** which evaluates the appropriateness of the PR for inclusion in SciCat, but without evaluated the implementation details. Conceptual reviews should be clearly indicated in the review comments.
 - Review period: **minimum 1 week, maximum 2 weeks**.
 
 #### Lower-Impact Pull Requests


### PR DESCRIPTION

## Description

This was discussed as a possible solution to reduce code review effort. We would still like reviews from two institutions, but allowing a conceptual review broadens the reviewer base and reduces the effort required.

This was discussed in today's dev meeting.

## Impact Classification

- [x] Large impact
- [ ] Lower impact

## AI Contributions

PRs are the responsibility of the human submitter, as described in the [contributing guidelines](../procedures/CONTRIBUTING.md#ai-contribution). Check one:
- [x] Fully human coded
- [ ] Assisted-by:

## Checklist

- [x] Code follows project conventions
- [x] All tests pass
- [x] Documentation updated (if applicable)
- [x] Changes have been reviewed

## Additional Notes
