### PR TITLE
Add RATIFICATION and AMENDMENT procedures

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ _IMPORTANT: these governance document are still a work-in-progress_
 ## Introduction
 
 The purpose of this repository is to formalize the governance process that the SciCat project follows and has been using informally for the past few years.
-These documents clarify who has which responsibility, how decisions are made and how the various elements of our community interact.  
+These documents clarify who has which responsibility, how decisions are made and how the various elements of our community interact.
 It is based from [Bluesky governance](https://), which has been adapted from
 [GitHub's Minimum Viable Governance](https://github.blog/2021-07-22-minimum-viable-governance-lightweight-community-structure-foss-projects/).
 
@@ -37,7 +37,7 @@ The Governance Entities of the Project are set in place to promote a positive de
 
 ## Governance Components
 
-### Governance Entities  
+### Governance Entities
 
 - [Users Community](./governance-entities/USERS-COMMUNITY.md)
 - [Contributors Community](./governance-entities/CONTRIBUTORS-COMMUNITY.md)
@@ -57,6 +57,8 @@ The Governance Entities of the Project are set in place to promote a positive de
 
 ### Procedures
 
+- [Ratification](./procedures/RATIFICATION.md)
+- [Amendment](./procedures/AMENDMENTS.md)
 - [Voting](./procedures/VOTING.md)
 - [Nomination](./procedures/NOMINATION.md)
 - [Member Early Dismissal](./procedures/MEMBER_DISMISSAL.md)
@@ -81,10 +83,10 @@ The Governance Entities of the Project are set in place to promote a positive de
 
 ## Status
 
-These documents are in active development. They have been adapted from:  
+These documents are in active development. They have been adapted from:
 
-- [Bluesky Governance](https://), which have been derived from the  
-- [GitHub's Minimum Viable Governance](https://github.com/github/MVG).  
+- [Bluesky Governance](https://), which have been derived from the
+- [GitHub's Minimum Viable Governance](https://github.com/github/MVG).
 
 We are in Step 2 of the following process:
 
@@ -92,7 +94,7 @@ We are in Step 2 of the following process:
 2. Collect feedback and contributions from Collaborators and the Community
    Please use GitHub Issues and PRs on this repository to provide feedback anc contributions.
 3. Content revision based on feedback.
-4. Announce initial memberships for each group and committee and maintainers for each repo, if possible.  
+4. Announce initial memberships for each group and committee and maintainers for each repo, if possible.
 
 Even if we are in step 2, we already working to find Project Leaders, and forming the Main Technical Committee.
 

--- a/governance-entities/CONTRIBUTORS-COMMUNITY.md
+++ b/governance-entities/CONTRIBUTORS-COMMUNITY.md
@@ -5,6 +5,7 @@
 CC = Contributors Community
 AC = Active Contributors
 PC = Past Contributors
+VB = [Voting Body](./VOTING-BODY.md)
 
 ## Description
 
@@ -16,9 +17,9 @@ Contributions can be in the form of code PR, documentation, dissemination, manag
 Everybody is welcome to the contributors community, although it is suggested a certain level of proficiency with the tools, the code base, the technology stack, project management or sustainability experience in order to maximize productivity of the contributed effort with the time constraints in place.
 Contributors Community has two type of members:
 
-- _active contributors_:  
+- _active contributors_:
   Any contributors that is currently contributing or has contributed to the project in the previous year
-- _past contributors_:  
+- _past contributors_:
   Any contributors that has contributed to the project in the past but not in the last year
 
 ## Responsibilities
@@ -40,7 +41,7 @@ Each meeting will be announced in due time together with an agenda, which will i
 
 ## Voting Body
 
-The CC voting body includes all the Active Contributors including the Project Leaders, but it does not include _past contributors_
+The voting body (VB) includes all the Active Contributors including the Project Leaders, but it does not include _past contributors_.
 
 ## Decision making process
 

--- a/governance-entities/PROJECT-LEADERS.md
+++ b/governance-entities/PROJECT-LEADERS.md
@@ -2,10 +2,10 @@
 
 ## Abbreviations
 
-PL = Project Leader(s)  
-SC = [Steering Committee](./STEERING-COMMITTEE.md)  
-CC = [Contributors Community](./CONTRIBUTORS-COMMUNITY.md)  
-Project = [SciCat Project](../project-components/SCICAT-PROJECT.md)  
+PL = Project Leader(s)
+SC = [Steering Committee](./STEERING-COMMITTEE.md)
+CC = [Contributors Community](./CONTRIBUTORS-COMMUNITY.md)
+Project = [SciCat Project](../project-components/SCICAT-PROJECT.md)
 
 ## Description
 
@@ -13,13 +13,13 @@ The Project Leaders (PL) are elected members of the Contributors Community taske
 
 ## Group Structure
 
-The Project Leaders group is composed by 3 or 5 elected members. There must be at least 3 members in the PL group and its members should always by an odd number.  
+The Project Leaders group is composed by 3 or 5 elected members. There must be at least 3 members in the PL group and its members should always by an odd number.
 The group should encompass a set of skill covering the following domains: technical, management, and public relation.
 Each member can bring experience in one or more of such area, as long as a whole the group provides a balanced and productive mixed of the required skills to run the project.
 
 ## Duties and Responsibilities
 
-The PL's duties and responsabilities are:
+The PL's duties and responsibilities are:
 
 - be the public face of the project
 - promote the project,
@@ -39,21 +39,21 @@ The PL's duties and responsabilities are:
 
 ## Effort
 
-PL do agree to put as much effort as required in performing the responsabilities highglighted.
+PL do agree to put as much effort as required in performing the responsibilities highlighted.
 
 ## Eligibility
 
 Any member of the Contributors Community is eligible to be nominated to become a Project Leader, proven that:
 
-- they have a solid knowledge of the Project,  
-- they are associated with a supporting facility.  
+- they have a solid knowledge of the Project,
+- they are associated with a supporting facility.
 
 They might be asked to sustain one or more interviews with any of the Project governing entities. The interviews will be decided by the current PL on per-nomination case, with the guidance of the SC.
 The nomination for a PL position should follow the process described in the [Nomination](../procedures/NOMINATION.md) section.
 
 ## NOMINATION
 
-For each open position as a Project Leader, any member of the Contributors Community who is eligible can be nominated as candidate according to the rules and conditions explained under the [Nomination](../procedures/NOMINATION.md) section.  
+For each open position as a Project Leader, any member of the Contributors Community who is eligible can be nominated as candidate according to the rules and conditions explained under the [Nomination](../procedures/NOMINATION.md) section.
 
 ## Election
 
@@ -62,7 +62,7 @@ The voting procedure will follow the procedure described in the [Voting](../proc
 
 ## Duration
 
-Project Leaders maintain their role for a three plus three years mandate. At the end of the first three years mandate, the outgoing PL can decide to renew their condidacies for the following three years and participate in the next round of elections.
+Project Leaders maintain their role for a three plus three years mandate. At the end of the first three years mandate, the outgoing PL can decide to renew their candidacies for the following three years and participate in the next round of elections.
 
 ## Resignation
 
@@ -71,10 +71,6 @@ At any time, an elected PL can resign from his/her position by submitting a writ
 ## Early dismissal
 
 At any time, a PL can be asked to resign from the PL role following conflicts or leadership related issues. This event must follow the process described in the [Member Dismissal](../procedures/MEMBER_DISMISSAL.md) section.
-
-## Effort
-
-It should be clear that been a PL entails more responsibilities, requires more commitment and a higher level of effort.
 
 ***
 Licensed under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) License.

--- a/governance-entities/TECHNICAL-LEADERS.md
+++ b/governance-entities/TECHNICAL-LEADERS.md
@@ -5,6 +5,7 @@
 TL = Technical Leader
 CC = [Contributors Community](./CONTRIBUTORS-COMMUNITY.md)
 SS = [Supported Project](../project-components/SUPPORTED-PROJECTS.md)
+VB = [Voting Body](./VOTING-BODY.md)
 
 ## Description
 
@@ -20,7 +21,7 @@ TL's responsibilities are:
 - managing activities necessary to achieve of objectives within their tasked area.
 - work independently,
 - be able to find adequate resources
-- be confortable to ask for help if needed
+- be comfortable to ask for help if needed
 - be able to report clearly and effectively the status of their sub-project to any interested party and stakeholder.
 
 ## Eligibility
@@ -29,10 +30,10 @@ Any member of the Contributors Community (CC) can become a TL, given that he/she
 
 ## Nomination Process
 
-A TL prospect is nominated through a public announcement on the official channels. The nomination for a TL position should follow the process described in the [Nomination](../procedures/NOMINATION.md) section. A TL is official after a winning an official election held during a Collaboration meeting (please see [Voting](../procedures/VOTING.md)).
+A TL prospect is nominated through a public announcement on the official channels. The nomination for a TL position should follow the process described in the [Nomination](../procedures/NOMINATION.md) section. A TL is official after winning an election by the VB (see [Voting](../procedures/VOTING.md)).
 
-The name of the TL must posted on the Project website and inserted in the related role file with the title of TL.  
-For supported project, the project repository should contain a file named GOVERNANCE.md listing the name of the offical TL and, possibly, the official maintainers
+The name of the TL must be listed in the relevant file under `roles/` and the Project website and updated following election results.
+For supported project, the project repository should contain a file named GOVERNANCE.md listing the name of the official TL and, possibly, the official maintainers
 
 ## Posting Duration
 

--- a/governance-entities/VOTING-BODY.md
+++ b/governance-entities/VOTING-BODY.md
@@ -10,12 +10,12 @@ AC = [Active Contributors](../governance-entities/CONTRIBUTORS-COMMUNITY.md)
 
 ## Definition
 
-The Voting Body is the group of people that are eligible to participate in the vote.  
-Unless stated otherwise, the VB is composed by the members of the Steering Committee (SC), the Project Leaders (PL) and the Active Contributors (AC) that are present during the official time allocated for the vote. The official time of the election should be publicly announced through the offical Project Channels (PC).  
-If the matter at hand requires changes to the VB, the changes requested should be:  
+The Voting Body is the group of people that are eligible to participate in the vote.
+Unless stated otherwise, the VB is composed by the members of the Steering Committee (SC), the Project Leaders (PL) and the Active Contributors (AC) that are present during the official time allocated for the vote. The official time of the election should be publicly announced through the official Project Channels (PC).
+If the matter at hand requires changes to the VB, the changes requested should be:
 
 - discussed in advanced with the Project Leaders (PL),
-- publicly announced on the offical Project Channels (PC) together with the vote announcment,
+- publicly announced on the official Project Channels (PC) together with the vote announcement,
 - well documented in the vote minutes
 
 ***

--- a/procedures/AMENDMENTS.md
+++ b/procedures/AMENDMENTS.md
@@ -1,0 +1,95 @@
+# Governance Amendments
+
+## Abbreviations and Links
+
+SC = [Steering Committee](../governance-entities/STEERING-COMMITTEE.md)
+AC = [Active Contributors](../governance-entities/CONTRIBUTORS-COMMUNITY.md)
+PL = [Project Leaders](../governance-entities/PROJECT-LEADERS.md)
+PC = [Project Channels](../project-components/PROJECT-CHANNELS.md)
+Project = [SciCat Project](../project-components/SCICAT-PROJECT.md)
+
+## Purpose
+
+This document defines how the SciCat governance documents are amended after initial ratification.
+
+## Scope
+
+Amendments apply to the following documents:
+
+- `governance-entities/`
+- `roles/`
+- `procedures/`
+
+Documents under `other/`, `project-components` and `utils/` are not subject to this procedure. They may be updated with approval by the Project Leaders (PL).
+
+## Document Versions
+
+- The **authoritative version** of the governed documents is the latest [GitHub release](https://github.com/SciCatProject/governance/releases) of this repository.
+- An approved amendment takes effect when incorporated into a new GitHub release. Until then, the previously ratified release remains authoritative.
+
+Tags follow semantic versioning, starting at `v1.0.0` and with the following interpretation:
+
+- Major versions indicate amendments to in-scope documents that have been approved following the procedure below
+- Minor versions indicate changes to out-of-scope documents. For example, election results are recorded in `roles/` and trigger a minor release.
+- Patch versions are for minor spelling or formatting changes.
+
+## Amendment Procedure
+
+### Proposal
+
+Any Active Contributor may propose an amendment by pull request to this repository. The pull request must clearly describe the change and its rationale.
+
+### Approval
+
+An amendment requires approval from both voting bodies:
+
+1. **SC** — at least two-thirds (2/3) of votes cast
+2. **AC** — at least two-thirds (2/3) of votes cast
+
+### Quorum
+
+The same quorum requirements as [Ratification](./RATIFICATION.md#quorum) apply:
+
+- **SC:** at least 2/3 of SC members must participate
+- **AC:** at least 15 Active Contributors must participate
+
+### Venue and Timing
+
+Amendment votes are held at the annual SciCatCon meeting when possible. If SciCatCon is not feasible, a special session may be called by the Project Leaders.
+
+Remote participation is permitted and count toward quorum and vote totals.
+
+### Announcement and Discussion
+
+Amendments must be publicly announced through the official Project Channels (PC) with reasonable advance notice. The announcement must identify:
+
+- the pull request under vote
+- the date and location (or remote access details) of the vote
+- the eligible voting bodies and quorum requirements
+
+A public discussion period should precede the vote, as described in the [Voting](./VOTING.md) document.
+
+### Effect
+
+An approved amendment takes effect when incorporated into a new GitHub release. Until then, the previously ratified release remains authoritative.
+
+Results must be documented and published through the official PC.
+
+## Relationship to Other Procedures
+
+- Amendment votes use the supermajority thresholds defined in this document.
+- Initial ratification follows the [Ratification](./RATIFICATION.md) procedure.
+- Other Project decisions follow the [Voting](./VOTING.md) procedure unless this document states otherwise.
+- Documents not included in the scope may be updated with approval from a PL without the amendment procedure in this document.
+
+## Records
+
+Amendment results must be recorded and made publicly accessible through the official PC, including:
+
+- the amendment pull request
+- quorum attainment for each voting body
+- vote totals
+- the effective date or release tag
+
+***
+Licensed under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) License.

--- a/procedures/NOMINATION.md
+++ b/procedures/NOMINATION.md
@@ -2,12 +2,12 @@
 
 ## Abbreviations and Links
 
-AC = [Active Contributor](../governance-entities/CONTRIBUTORS-COMMUNITY.md)  
-PL = [Project Leaders](../governance-entities/PROJECT-LEADERS.md)  
-TL = [Technical Leaders](../governance-entities/TECHNICAL-LEADERS.md)  
-PC = [Official Project Channels](../project-components/PROJECT-CHANNELS.md)  
-Project = [SciCat Project](../project-components/SCICAT-PROJECT.md)  
-vote = [Voting](../procedures/VOTING.md)  
+AC = [Active Contributor](../governance-entities/CONTRIBUTORS-COMMUNITY.md)
+PL = [Project Leaders](../governance-entities/PROJECT-LEADERS.md)
+TL = [Technical Leaders](../governance-entities/TECHNICAL-LEADERS.md)
+PC = [Official Project Channels](../project-components/PROJECT-CHANNELS.md)
+Project = [SciCat Project](../project-components/SCICAT-PROJECT.md)
+vote = [Voting](../procedures/VOTING.md)
 
 ## Description
 
@@ -19,15 +19,15 @@ The eligibility criteria are described in the governance document of the related
 
 Candidates for open positions as Project Leader or Technical Leader of core or supported projects should follow this process:
 
-- the open position should be advertised through the Official Project Channels.  
+- the open position should be advertised through the Official Project Channels.
 - a set date should be indicated when nomination will be accepted.
-- the nomination period will be one month starting from the set date.  
-- candidate nomination should be submitted by one or, preferrably, both the following methods:
+- the nomination period will be one month starting from the set date.
+- candidate nomination should be submitted by one or, preferably, both the following methods:
   - direct email to one or more Project Leaders or Steering Committee members
   - a posting on the Official Project Channels.
-- each candidate should have the support from at least three other project members. One of them should be from a different institution.
+- each candidate should have the support from at least two other project members. One of them should be from a different institution.
 - the nomination can be initiate directly by the candidate or by one of the supporting members.
-- the nomination becomes official when listed in the relevant section of the project website
+- the nomination becomes official when listed in the relevant file under `roles/`
 
 ## Important
 

--- a/procedures/RATIFICATION.md
+++ b/procedures/RATIFICATION.md
@@ -1,0 +1,82 @@
+# Governance Ratification
+
+## Abbreviations and Links
+
+SC = [Steering Committee](../governance-entities/STEERING-COMMITTEE.md)
+AC = [Active Contributors](../governance-entities/CONTRIBUTORS-COMMUNITY.md)
+PL = [Project Leaders](../governance-entities/PROJECT-LEADERS.md)
+TL = [Technical Leaders](../governance-entities/TECHNICAL-LEADERS.md)
+PC = [Project Channels](../project-components/PROJECT-CHANNELS.md)
+Project = [SciCat Project](../project-components/SCICAT-PROJECT.md)
+
+## Purpose
+
+This document defines how the SciCat governance documents are ratified and brought into effect.
+
+## Document Versions
+
+- The **authoritative version** of the governing documents is the latest [GitHub release](https://github.com/SciCatProject/governance/releases) of this repository.
+- Governance versions follow semantic versioning, as described in [Amendments](./AMENDMENTS.md)
+- The `main` branch is considered a **draft** and is not in effect until incorporated into a release following the procedures in this document.
+
+## Pre-Ratification Status
+
+Until the governed documents are ratified under this procedure, they are draft guidance only and are not binding on the Project community.
+
+## Ratification
+
+### Proposal
+
+The ratification vote will be applied to the `main` branch of this repository. After ratification, governance documents will be tagged and published as a release. Further amendments will be made as described in [AMENDMENTS](./AMENDMENTS.md).
+
+### Voting Bodies
+
+Ratification requires approval from two separate voting bodies:
+
+1. **Steering Committee (SC)** — unanimous approval
+2. **Active Contributors (AC)** — approval by at least two-thirds (2/3) of votes cast
+
+Only Active Contributors may vote in the AC ratification. Past contributors who are not Active Contributors are not eligible.
+
+### Quorum
+
+- **SC:** at least two-thirds (2/3) of SC members must participate (in person or remotely).
+- **AC:** at least fifteen (15) Active Contributors must participate (in person or remotely).
+
+If quorum is not met, the vote does not take effect and may be rescheduled.
+
+### Venue and Timing
+
+The ratification vote will be held at the 2026 SciCatCon meeting.
+
+Remote participation is permitted and counts toward quorum and vote totals.
+
+### Administration
+
+Until Project Leaders are elected under the ratified governance, the current project leader (**Max Novelli**) administers the ratification vote and the first election of Project Leaders and Technical Leaders.
+
+### Effect
+
+Upon successful ratification, the approved branch will be tagged as `v1.0.0` and designated as a github release. It then becomes the authoritative version of the governed documents. Results must be documented and published through the official PC.
+
+## Initial Elections
+
+Elections for Project Leader (PL) and Technical Leader (TL) positions will be held following approval of the governance documents. Nominations follow the [Nomination](./NOMINATION.md) procedure. Elections follow the [Voting](./VOTING.md) procedure, except where this document or the pre-ratification administration provisions apply.
+
+## Relationship to Other Procedures
+
+- Ratification votes use the supermajority thresholds defined in this document.
+- Amendments to governed documents follow the [Amendments](./AMENDMENTS.md) procedure.
+- Other Project decisions follow the [Voting](./VOTING.md) procedure unless this document states otherwise.
+
+## Records
+
+Ratification results must be recorded and made publicly accessible through the official PC, including:
+
+- the commit under vote
+- quorum attainment for each voting body
+- vote totals
+- the effective date or release tag
+
+***
+Licensed under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) License.

--- a/procedures/VOTING.md
+++ b/procedures/VOTING.md
@@ -2,11 +2,11 @@
 
 ## Abbreviations and Links
 
-PC = [Project Channels](../project-components/PROJECT-CHANNELS.md)  
-VB = [Voting Body](../governance-entities/VOTING-BODY.md)  
-PL = [Project Leaders](../governance-entities/PROJECT-LEADERS.md)  
-SC = [Steering committee](../governance-entities/STEERING-COMMITTEE.md)  
-Project = [SciCat Project](../project-components/SUPPORTED-PROJECTS.md)  
+PC = [Project Channels](../project-components/PROJECT-CHANNELS.md)
+VB = [Voting Body](../governance-entities/VOTING-BODY.md)
+PL = [Project Leaders](../governance-entities/PROJECT-LEADERS.md)
+SC = [Steering committee](../governance-entities/STEERING-COMMITTEE.md)
+Project = [SciCat Project](../project-components/SUPPORTED-PROJECTS.md)
 
 ## Announcement
 
@@ -20,7 +20,7 @@ An official announcement should be made through the official PC, and it should i
 
 ## Discussion
 
-A discussion period should preceed time of the voting. Any discussion may be conducted in person or electronically by text, voice, or video. The discussion will be open to the public and should be accessible through the official PC.
+A discussion period should precede the time of the voting. Any discussion may be conducted in person or electronically by text, voice, or video. The discussion will be open to the public and should be accessible through the official PC.
 
 ## Decision Making
 
@@ -32,10 +32,14 @@ If a decision cannot be reached at all, the PL will seek out the guidance of the
 
 In any voting, each member of the VB will have one vote, and all the votes are equal.
 
+### Delegation
+
+In the case of absence during a vote, VB members may temporarily delegate their vote to another person by emailing the Project Leaders.
+
 ## Responsibilities
 
 It is the duty of the PL to call a vote on the matter at hand with reasonable notice and inform all the interested parties, better if the whole project, and, specifically, the project members eligible to vote.
-The PL will be the guaranteers of the vote. They also have the duty to document and report the results back to the community.
+The PL will be the guarantors of the vote. They also have the duty to document and report the results back to the community.
 
 ## Results
 

--- a/roles/PROJECT-LEADERS.md
+++ b/roles/PROJECT-LEADERS.md
@@ -1,6 +1,6 @@
 # Project Leaders (PL)
 
-This document lists the members of the Organization's Project Leaders or PL. Each PL members may be added only after approval of the remaining PL, by the SC. By adding your name to one of the position listed in this document, you are agreeing to abide by all Organization polices, including the organizational charter document, the code of conduct, and the antitrust policy.
+This document lists nominated candidates for Project Leader (PL) positions. Entries reflect nominations under the [Nomination](../procedures/NOMINATION.md) procedure and are updated to record election results. By adding your name to this document, you are agreeing to abide by all Organization policies, including the organizational charter document, the code of conduct, and the antitrust policy.
 
 | **POSITION** | **NAME** | **GitHub Handle** | **Affiliated Organization** | **Mandate started** |
 | --- | --- | --- | --- | --- |

--- a/roles/TECHNICAL-LEADERS.md
+++ b/roles/TECHNICAL-LEADERS.md
@@ -1,7 +1,6 @@
 # Technical Leaders (TL)
 
-This document lists the Technical Leaders or TL for Core efforts or Supported projects. Each TL  may be added only after approval of the Project Leaders (PL).
-By adding your name to one of the position listed in this document, you are agreeing to abide by all Organization polices, including the organizational charter document, the code of conduct, and the antitrust policy.
+This document lists nominated candidates for Technical Leader (TL) positions for Core efforts or Supported projects. Entries reflect nominations under the [Nomination](../procedures/NOMINATION.md) procedure and are updated to record election results. By adding your name to this document, you are agreeing to abide by all Organization policies, including the organizational charter document, the code of conduct, and the antitrust policy.
 
 | **EFFORT/PROJECT** | **NAME** | **GitHub Handle** | **Affiliated Organization** | **Mandate started** |
 | --- | --- | --- | --- | --- |

--- a/utils/manifest.txt
+++ b/utils/manifest.txt
@@ -11,6 +11,8 @@
 ../project-components/SCICAT-CORE.md
 ../project-components/SUPPORTED-PROJECTS.md
 ../project-components/PROJECT-CHANNELS.md
+../procedures/RATIFICATION.md
+../procedures/AMENDMENTS.md
 ../procedures/VOTING.md
 ../procedures/NOMINATION.md
 ../procedures/MEMBER_EARLY_DISMISSAL.md


### PR DESCRIPTION
# Pull Request

## Description

This is a proposal for the procedures to ratify the governance docs and provide for future amendments.

It's written more formally in the PR, but the basic suggestion would be:
1. `main` is considered the draft governance. Merge (or close) all PRs before SciCatCon
2. The SC meets 2026-06-30 10:00 CEST to discuss the draft. They hold a formal vote to approve the governance. This should be unanimous (otherwise we should change things).
3. Later that day we should have a CC meeting. First the VB votes to ratify, requiring a supermajority to approve.
4. Next we have elections for the PL and TL.
5. The repo is updated with the election results, tagged `v1.0.0`, and a release is made. 

All votes should allow remote participation if needed.

## Impact Classification

- [x] Large impact
- [ ] Lower impact

## AI Contributions

PRs are the responsibility of the human submitter, as described in the [contributing guidelines](../procedures/CONTRIBUTING.md#ai-contribution). Check one:
- [ ] Fully human coded
- [x] Assisted-by: Cursor (polishing language, checking consistency across documents)

## Checklist

- [ ] Code follows project conventions
- [ ] All tests pass
- [ ] Documentation updated (if applicable)
- [x] Changes have been reviewed

## Additional Notes
